### PR TITLE
Support users on Adobe Forums

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -1,6 +1,6 @@
 # Resources and support
 
-Adobe I/O Runtime is built on top of Apache OpenWhisk. This is why many of the resources written for Apache OpenWhisk apply to Adobe I/O Runtime, too: blogs, documentation and references, and so forth. 
+Adobe I/O Runtime is built on top of Apache OpenWhisk. This is why many of the resources written for Apache OpenWhisk apply to Adobe I/O Runtime, too: blogs, documentation and references, and so forth.
 
 For a starter, a good resource to check is the [Apache OpenWhisk repository](https://github.com/apache/incubator-openwhisk/tree/master/docs).
 
@@ -10,7 +10,7 @@ You can follow up our team on [Twitter](https://twitter.com/adobeio), [Medium](h
 
 ## Support
 
-If you have issues with Adobe I/O Runtime, you can use our [Zendesk channel](https://adobeio.zendesk.com).
+If you have issues with Adobe I/O Runtime, you can use our [Adobe I/O Runtime Forum](https://forums.adobe.com/community/adobe-io/adobe-io-runtime).
 
 If you have issues with the documentation, you can always submit a pull request.
 


### PR DESCRIPTION
Currently folks start on the adobe.io website click on the Runtime docs link and land in this repo. They read the `resouces.md` file which tells you to go to Zendesk for support. That Zendesk is an external instance that customers can't open tickets on so instead there is a note that sends folks to the Developer Support Page which then in turn sends you to the external Zendesk in order to create a ticket.

In case you haven't been counting the clicks that's 5 clicks and 4 different web properties.

This PR short circuits that route by sending folks directly to the Adobe Forums to ask questions. Feel free to schedule a call with me and I'll show you the flow and how this improves things.