### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -48,6 +48,12 @@
           "pages": [],
           "path": "adobedocs/adobeio-runtime/master/overview/entities.md",
           "title": "Adobe I/O Runtime Entities"
+        },
+        {
+          "importedFileName": "request_a_trial",
+          "pages": [],
+          "path": "adobedocs/adobeio-runtime/master/overview/request_a_trial.md",
+          "title": "Request a Trial"
         }
       ],
       "path": "adobedocs/adobeio-runtime/master/overview.md",


### PR DESCRIPTION
Clicking "request a trial" link on this page: https://www.adobe.io/apis/experienceplatform/runtime/docs.html#!adobedocs/adobeio-runtime/master/overview.md 

Results in a file not found error. I believe updating the manifest file so it shows up in the left nav will fix this problem. I have added a request a trial section in the overview area of this manifest file.

Hey @mcorlan Can you take a look at this? Or is there someone else who should look at it?