### PR TITLE
Update getting_access.md

### DIFF
--- a/overview/getting_access.md
+++ b/overview/getting_access.md
@@ -1,26 +1,3 @@
 # Getting Access
 
-Adobe Customers & Partners wishing to try Adobe I/O Runtime may request a trial license. The trial license offers a fully functional version. See below for terms and conditions.
-
-Adobe I/O Runtime Trial Terms:
-* Valid for 6 months, renews automatically
-* SLA performance guarantee is not included
-* Transitioning to licensed version is seamless - no disruption in service.
- 
-A fully licensed version backed by SLA along with unlimited namespace creation is available now. Talk with your Adobe account team for more details. Enterprise customers may want to validate their useage with a trial before purchasing. 
-
-## Request a trial
-Runtime is available as part of **Project Firefly**.
-
-Project Firefly is built on top of existing Adobe technologies, including I/O Runtime and I/O Events. [Project Firefly](https://www.adobe.io/apis/experienceplatform/project-firefly.html) is a complete developer framework to build custom web apps that extend the functionality of Adobe Experience Platform and Adobe Experience Cloud solutions. Gain productivity and developer convenience with Project Firefly's front- and back end tools. 
-
-Our trial application process has two simple steps. First, start on our [Typeform](https://adobeio.typeform.com/to/obqgRm). Here we'll ask you a few details like name, email, the Adobe IMS org you want to use and your use case.
-
-* Your Adobe organization ID and organization name. We are granting access to organizations, not to individuals. You can retrieve your Organization ID and name from [Adobe Admin Console](https://adminconsole.adobe.com), the ID is part of the URL (something like some_hash@AdobeOrg) and the name is listed in the top-right corner
-* Describe your use case. For example: “I want to extend/integrate Adobe Experience Platform” or “Adobe Experience Manager”
-
-At the end of typeform you will be asked to click through to the trial agreement. We are using our prerelease system to manage trial agreements.
-
-* Once your organization has been onboarded, anyone who has a Developer Role or System Administrator permissions will be able to create projects for Firefly in the [Developer Console](https://console.adobe.io)
-
-We look forward to seeing what you will build with Project Firefly and Adobe I/O Runtime! 
+Adobe I/O Runtime is no longer available as a standalone trial. Adobe Customers & Partners who want to try Adobe I/O Runtime may request access our Adobe Developer App Builder trial. [Click here](https://developer.adobe.com/app-builder/docs/overview/getting_access/) for more information.


### PR DESCRIPTION
Updating to point to App Builder trial as the Runtime trial is not longer valid.